### PR TITLE
[Fix]: Catastrophic backtracking with animline regex on multiline comments leading to engine freezes.

### DIFF
--- a/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/FNIS/FNISAnimationList.cs
+++ b/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/FNIS/FNISAnimationList.cs
@@ -50,7 +50,7 @@ public class FNISAnimationListBuildContext
 
 public partial class FNISAnimationList
 {
-	[GeneratedRegex("([^('|\\s)]+)\\s*(?:-(\\S+)*)?\\s*(\\S+)\\s+(\\S+.hkx)(?:[^\\S\\r\\n]+(\\S+))*", RegexOptions.Compiled)]
+	[GeneratedRegex("^([^('|\\s)]+)\\s*(?:-(\\S+)*)?\\s*(\\S+)\\s+(\\S+.hkx)(?:[^\\S\\r\\n]+(\\S+))*", RegexOptions.Compiled | RegexOptions.Multiline)]
 	private static partial Regex FNISAnimLineRegex();
 
 	private static readonly Regex animLineRegex = FNISAnimLineRegex();


### PR DESCRIPTION
closes #251 