### PR TITLE
Fixup support of -o for OutputFolder

### DIFF
--- a/PandoraPlus/MVVM/Model/Patch/IOManagers/Skyrim/DebugPackFileExporter.cs
+++ b/PandoraPlus/MVVM/Model/Patch/IOManagers/Skyrim/DebugPackFileExporter.cs
@@ -15,13 +15,15 @@ namespace Pandora.Patch.IOManagers.Skyrim
 	public class DebugPackFileExporter : Exporter<PackFile>
 	{
 		public DirectoryInfo ExportDirectory { get; set; }
-        public DebugPackFileExporter()
-        {
-			ExportDirectory = new DirectoryInfo(Path.Join(Directory.GetCurrentDirectory()));
-        }
-        public bool Export(PackFile packFile)
+		public DebugPackFileExporter()
 		{
-			var outputHandle = new FileInfo(Path.Join(ExportDirectory.FullName, Path.GetRelativePath(Directory.GetCurrentDirectory(), packFile.InputHandle.FullName.Replace("Pandora_Engine\\Skyrim\\Template", "meshes", StringComparison.OrdinalIgnoreCase))));
+			ExportDirectory = new DirectoryInfo(Path.Join(Directory.GetCurrentDirectory()));
+		}
+		public bool Export(PackFile packFile)
+		{
+			var launchDirectory = new FileInfo(System.Reflection.Assembly.GetEntryAssembly()!.Location).Directory!.FullName;
+
+			var outputHandle = new FileInfo(Path.Join(ExportDirectory.FullName, Path.GetRelativePath(launchDirectory, packFile.InputHandle.FullName.Replace("Pandora_Engine\\Skyrim\\Template", "meshes", StringComparison.OrdinalIgnoreCase))));
 
 			if (outputHandle.Directory == null) return false;
 			if (!outputHandle.Directory.Exists) { outputHandle.Directory.Create(); }

--- a/PandoraPlus/MVVM/Model/Patch/IOManagers/Skyrim/PackFileExporter.cs
+++ b/PandoraPlus/MVVM/Model/Patch/IOManagers/Skyrim/PackFileExporter.cs
@@ -26,7 +26,9 @@ public class PackFileExporter : Exporter<PackFile>
 
 	public bool Export(PackFile packFile)
 	{
-		var outputHandle = new FileInfo(Path.Join(ExportDirectory.FullName, Path.GetRelativePath(Directory.GetCurrentDirectory(), packFile.InputHandle.FullName.Replace("Pandora_Engine\\Skyrim\\Template", "meshes", StringComparison.OrdinalIgnoreCase))));
+		var launchDirectory = new FileInfo(System.Reflection.Assembly.GetEntryAssembly()!.Location).Directory!.FullName;
+
+		var outputHandle = new FileInfo(Path.Join(ExportDirectory.FullName, Path.GetRelativePath(launchDirectory, packFile.InputHandle.FullName.Replace("Pandora_Engine\\Skyrim\\Template", "meshes", StringComparison.OrdinalIgnoreCase))));
 
 		if (outputHandle.Directory == null) return false;
 		if (!outputHandle.Directory.Exists) { outputHandle.Directory.Create(); }

--- a/PandoraPlus/MVVM/Model/Patch/Patchers/Interface/IAssembler.cs
+++ b/PandoraPlus/MVVM/Model/Patch/Patchers/Interface/IAssembler.cs
@@ -30,5 +30,7 @@ namespace Pandora.Patch.Patchers
 
 		public List<(FileInfo inFile, FileInfo outFile)> GetExportFiles(); 
 
+		public void SetOutputPath(DirectoryInfo outputPath);
+
 	}
 }

--- a/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/AnimData/AnimDataManager.cs
+++ b/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/AnimData/AnimDataManager.cs
@@ -34,12 +34,19 @@ namespace Pandora.Patch.Patchers.Skyrim.AnimData
 
 		private int LastID { get; set; } = 32767;
 
-        public AnimDataManager(DirectoryInfo templateFolder, DirectoryInfo currentFolder)
-        {
+		public AnimDataManager(DirectoryInfo templateFolder, DirectoryInfo outputPath)
+		{
 			this.templateFolder = templateFolder;
-			this.outputFolder = new DirectoryInfo(Path.Join(currentFolder.FullName, "meshes"));
-            templateAnimDataSingleFile = new FileInfo($"{templateFolder.FullName}\\{ANIMDATA_FILENAME}");
-			outputAnimDataSingleFile = new FileInfo($"{outputFolder.FullName}\\{ANIMDATA_FILENAME}");
+			templateAnimDataSingleFile = new FileInfo($"{templateFolder.FullName}\\{ANIMDATA_FILENAME}");
+
+			this.outputFolder = new DirectoryInfo(Path.Join(outputPath.FullName, "meshes"));
+			outputAnimDataSingleFile = new FileInfo($"{this.outputFolder.FullName}\\{ANIMDATA_FILENAME}");
+		}
+
+		public void SetOutputPath(DirectoryInfo outputPath)
+		{
+			this.outputFolder = new DirectoryInfo(Path.Join(outputPath.FullName, "meshes"));
+			outputAnimDataSingleFile = new FileInfo($"{this.outputFolder.FullName}\\{ANIMDATA_FILENAME}");
 		}
 
 		private void MapProjectAnimData(ProjectAnimData animData)

--- a/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/AnimSetData/AnimSetDataManager.cs
+++ b/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/AnimSetData/AnimSetDataManager.cs
@@ -28,13 +28,20 @@ namespace Pandora.Patch.Patchers.Skyrim.AnimSetData
 
 		public Dictionary<string, ProjectAnimSetData> AnimSetDataMap { get; private set; } = new Dictionary<string, ProjectAnimSetData>();
 
-		public AnimSetDataManager(DirectoryInfo templateFolder, DirectoryInfo currentFolder)
-        {
+		public AnimSetDataManager(DirectoryInfo templateFolder, DirectoryInfo outputPath)
+		{
 			this.templateFolder = templateFolder;
-			this.outputFolder = new DirectoryInfo(Path.Join(currentFolder.FullName, "meshes"));
 			templateAnimSetDataSingleFile = new FileInfo($"{templateFolder.FullName}\\{ANIMSETDATA_FILENAME}");
-			outputAnimSetDataSingleFile = new FileInfo($"{outputFolder.FullName}\\{ANIMSETDATA_FILENAME}");
 			vanillaHkxFiles = new FileInfo($"{templateFolder.FullName}\\vanilla_hkxpaths.txt");
+
+			this.outputFolder = new DirectoryInfo(Path.Join(outputPath.FullName, "meshes"));
+			outputAnimSetDataSingleFile = new FileInfo($"{outputFolder.FullName}\\{ANIMSETDATA_FILENAME}");
+		}
+
+		public void SetOutputPath(DirectoryInfo outputPath)
+		{
+			this.outputFolder = new DirectoryInfo(Path.Join(outputPath.FullName, "meshes"));
+			outputAnimSetDataSingleFile = new FileInfo($"{outputFolder.FullName}\\{ANIMSETDATA_FILENAME}");
 		}
 
         public void SplitAnimSetDataSingleFile()

--- a/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/Nemesis/NemesisAssembler.cs
+++ b/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/Nemesis/NemesisAssembler.cs
@@ -40,7 +40,7 @@ public class NemesisAssembler : IAssembler //animdata and animsetdata deviate fr
 
 	private static readonly DirectoryInfo engineFolder = new DirectoryInfo(Directory.GetCurrentDirectory() + "\\Pandora_Engine");
 
-	private static readonly DirectoryInfo templateFolder = new DirectoryInfo(Directory.GetCurrentDirectory() + "\\Pandora_Engine\\Skyrim\\Template");
+	private static readonly DirectoryInfo templateFolder = new DirectoryInfo(new FileInfo(System.Reflection.Assembly.GetEntryAssembly()!.Location).Directory!.FullName + "\\Pandora_Engine\\Skyrim\\Template");
 
 	private static readonly DirectoryInfo outputFolder = new DirectoryInfo($"{Directory.GetCurrentDirectory()}\\meshes");
 	public ProjectManager ProjectManager { get; private set; }
@@ -80,7 +80,13 @@ public class NemesisAssembler : IAssembler //animdata and animsetdata deviate fr
 		pandoraConverter = new PandoraConverter(ProjectManager, AnimSetDataManager, AnimDataManager);
 	}
 
-    public void LoadResources()
+	public void SetOutputPath(DirectoryInfo outputPath)
+	{
+		AnimDataManager.SetOutputPath(outputPath);
+		AnimSetDataManager.SetOutputPath(outputPath);
+	}
+
+	public void LoadResources()
 	{
 		throw new NotImplementedException();
 

--- a/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/Pandora/PandoraAssembler.cs
+++ b/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/Pandora/PandoraAssembler.cs
@@ -56,6 +56,13 @@ namespace Pandora.Patch.Patchers.Skyrim.Pandora
 			this.AnimSetDataManager = animSDManager;
 			this.AnimDataManager = animDManager;
 		}
+
+		public void SetOutputPath(DirectoryInfo outputPath)
+		{
+			AnimDataManager.SetOutputPath(outputPath);
+			AnimSetDataManager.SetOutputPath(outputPath);
+		}
+
 		public void AssembleEdit(ChangeType changeType, XElement element, PackFile packFile,PackFileChangeSet changeSet)
 		{
 			XAttribute? pathAttribute = element.Attribute("path");

--- a/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/SkyrimPatcher.cs
+++ b/PandoraPlus/MVVM/Model/Patch/Patchers/Skyrim/SkyrimPatcher.cs
@@ -154,5 +154,7 @@ public class SkyrimPatcher : IPatcher
 	public void SetOutputPath(DirectoryInfo directoryInfo)
 	{
 		exporter.ExportDirectory = directoryInfo;
+		nemesisAssembler.SetOutputPath(directoryInfo);
+		pandoraAssembler.SetOutputPath(directoryInfo);
 	}
 }

--- a/PandoraPlus/MVVM/ViewModel/EngineViewModel.cs
+++ b/PandoraPlus/MVVM/ViewModel/EngineViewModel.cs
@@ -203,13 +203,15 @@ namespace Pandora.MVVM.ViewModel
 		}
         public async Task LoadAsync()
         {
-			
+            var launchDirectory = new FileInfo(System.Reflection.Assembly.GetEntryAssembly()!.Location).Directory!.FullName;
 
-			List<IModInfo> modInfos = new List<IModInfo>();
 
-			modInfos.AddRange(await nemesisModInfoProvider?.GetInstalledMods(currentDirectory + "\\Nemesis_Engine\\mod")!);
+            List<IModInfo> modInfos = new List<IModInfo>();
+
+            modInfos.AddRange(await nemesisModInfoProvider?.GetInstalledMods(launchDirectory + "\\Nemesis_Engine\\mod")!);
+            modInfos.AddRange(await pandoraModInfoProvider?.GetInstalledMods(launchDirectory + "\\Pandora_Engine\\mod")!);
+            modInfos.AddRange(await nemesisModInfoProvider?.GetInstalledMods(currentDirectory + "\\Nemesis_Engine\\mod")!);
 			modInfos.AddRange(await pandoraModInfoProvider?.GetInstalledMods(currentDirectory + "\\Pandora_Engine\\mod")!);
-
 
 			for (int i = 0; i < modInfos.Count; i++)
             {
@@ -227,7 +229,7 @@ namespace Pandora.MVVM.ViewModel
 
             modInfoCache = LoadActiveMods(modInfos);
 
-            modInfos = modInfos.OrderBy(m => m.Priority == 0).ThenBy(m => m.Priority).ToList();
+            modInfos = modInfos.OrderBy(m => m.Code == "pandora").OrderBy(m => m.Priority == 0).ThenBy(m => m.Priority).ThenBy(m => m.Name).ToList();
 
             foreach(var modInfo in modInfos) { Mods.Add(modInfo);  }
             await WriteLogBoxLine("Mods loaded.");


### PR DESCRIPTION
No longer require Templates to be installed in the Skyrim\Data folder

So, I tried to use this and was partly confused. LOOT said I needed to include it deployed (ala Nemesis), the instructions on the readme here said to install it outside of Skyrim\Data, but set the working folder to \Data and then use -o to set an Output path.

I found multiple cases where everything was read from the current directory, or written to the current directory mismatching what the -o setting was implying. I fixed several cases where the output folder wasn't set.

I've never been a fan of extra files deployed, so I configured the templates to load from the .exe folder as well as the current folder gathering both the deployed and non-deployed templates. The base ordering was also updated to sort by name as a last resort.

If i infered anything terribly wrong, I'll be happy to fix it. I try not to force my personal flavor of coding on others, but you had a mix of tabs and spaces, so, i just didn't change anything i didn't already have to change. :)

Hope this changeset helps. Thanks for the project. Looking good!