### PR TITLE
clear folder if the -o folder if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/Pandora Behaviour Engine/Properties/launchSettings.json

--- a/Pandora Behaviour Engine/Models/Patch/Engine/BehaviourEngine.cs
+++ b/Pandora Behaviour Engine/Models/Patch/Engine/BehaviourEngine.cs
@@ -10,8 +10,18 @@ namespace Pandora.Core
 {
 	public class BehaviourEngine
 	{
-		public static readonly DirectoryInfo AssemblyDirectory = new FileInfo(System.Reflection.Assembly.GetEntryAssembly()!.Location).Directory!; 
+		public static readonly DirectoryInfo AssemblyDirectory = new FileInfo(System.Reflection.Assembly.GetEntryAssembly()!.Location).Directory!;
 		public IEngineConfiguration Configuration { get; private set; } = new SkyrimConfiguration();
+
+		private bool ClearOutputPath = false;
+        private DirectoryInfo CurrentPath { get; } = new DirectoryInfo(Directory.GetCurrentDirectory());
+        public DirectoryInfo OutputPath { get; private set; } = new DirectoryInfo(Directory.GetCurrentDirectory());
+        public void SetOutputPath(DirectoryInfo outputPath)
+		{
+			ClearOutputPath = (outputPath != CurrentPath);
+			OutputPath = outputPath!;
+			Configuration.Patcher.SetOutputPath(outputPath);
+		}
 
         public BehaviourEngine()
         {
@@ -33,12 +43,39 @@ namespace Pandora.Core
 		{
 			Configuration.Patcher.SetTarget(mods);
 
-			if (!await Configuration.Patcher.UpdateAsync()) { return false; }
+			if (!OutputPath.Exists) OutputPath.Create();
+
+			if (ClearOutputPath)
+            {
+                ClearFolder(OutputPath);
+            }
+
+            //File.Copy(Path.Combine(AssemblyDirectory.FullName, "FNIS.esp"), Path.Combine(OutputPath.FullName, "FNIS.esp"), true);
+
+            if (!await Configuration.Patcher.UpdateAsync()) { return false; }
 
 			return await Configuration.Patcher.RunAsync();
 		}
 
-		public async Task PreloadAsync()
+        private void ClearFolder(DirectoryInfo dir)
+        {
+            foreach (var item in dir.GetFiles())
+            {
+                if (item.Name.Equals("ActiveMods.txt", StringComparison.InvariantCultureIgnoreCase))
+					continue;
+				else
+                    item.Delete();
+            }
+            foreach (var item in dir.GetDirectories())
+            {
+				if (item.Name.Equals("Pandora_Engine", StringComparison.InvariantCultureIgnoreCase))
+					ClearFolder(item);
+				else
+					item.Delete(true);
+            }
+        }
+
+        public async Task PreloadAsync()
 		{
 			await Configuration.Patcher.PreloadAsync();
 		}

--- a/Pandora Behaviour Engine/Models/Patch/Engine/BehaviourEngine.cs
+++ b/Pandora Behaviour Engine/Models/Patch/Engine/BehaviourEngine.cs
@@ -50,7 +50,9 @@ namespace Pandora.Core
                 ClearFolder(OutputPath);
             }
 
-            //File.Copy(Path.Combine(AssemblyDirectory.FullName, "FNIS.esp"), Path.Combine(OutputPath.FullName, "FNIS.esp"), true);
+			var fnisESP = new FileInfo(Path.Combine(AssemblyDirectory.FullName, "FNIS.esp"));
+			if (fnisESP.Exists)
+				fnisESP.CopyTo(Path.Combine(OutputPath.FullName, "FNIS.esp"), true);
 
             if (!await Configuration.Patcher.UpdateAsync()) { return false; }
 

--- a/Pandora Behaviour Engine/Models/Patch/Patchers/Skyrim/AnimData/MotionData.cs
+++ b/Pandora Behaviour Engine/Models/Patch/Patchers/Skyrim/AnimData/MotionData.cs
@@ -31,7 +31,6 @@ public class MotionData
 
 			whiteSpace = reader.ReadLine();
 			i++;
-
 		}
 		return project;
 	}

--- a/Pandora Behaviour Engine/Models/Patch/Patchers/Skyrim/AnimData/ProjectAnimData.cs
+++ b/Pandora Behaviour Engine/Models/Patch/Patchers/Skyrim/AnimData/ProjectAnimData.cs
@@ -49,7 +49,7 @@ namespace Pandora.Patch.Patchers.Skyrim.AnimData
 			project.Header = ProjectAnimDataHeader.ReadBlock(reader);
 
 			int i = project.Header.GetLineCount() + 1; //+1 to account for 1 empty line 
-			string whiteSpace = "";
+			string? whiteSpace = "";
 
 			while (whiteSpace != null && i < lineLimit)
 			{
@@ -59,7 +59,6 @@ namespace Pandora.Patch.Patchers.Skyrim.AnimData
 
 				whiteSpace = reader.ReadLine();
 				i++;
-
 			}
 			return project;
 		}
@@ -68,37 +67,30 @@ namespace Pandora.Patch.Patchers.Skyrim.AnimData
 			ProjectAnimData project = new ProjectAnimData(manager);
 			project.Header = ProjectAnimDataHeader.ReadBlock(reader);
 
-
-			string whiteSpace = "";
+			string? whiteSpace = "";
 			while (whiteSpace != null)
 			{
 				ClipDataBlock block = ClipDataBlock.ReadBlock(reader);
 				project.Blocks.Add(block);
 
 				whiteSpace = reader.ReadLine();
-
 			}
 			return project;
 		}
 		public static ProjectAnimData ExtractProject(StreamReader reader, string openString, string closeString, AnimDataManager manager)
 		{
-			string s;
-			while (!(s = reader.ReadLine()).Contains(openString))
-			{
+			while (reader.ReadLine()?.Contains(openString) == false) ;
 
-			}
 			ProjectAnimData project = new ProjectAnimData(manager);
 			project.Header = ProjectAnimDataHeader.ReadBlock(reader);
 
-
-			string whiteSpace = "";
+			string? whiteSpace = "";
 			while (whiteSpace != null && !whiteSpace.Contains(closeString))
 			{
 				ClipDataBlock block = ClipDataBlock.ReadBlock(reader);
 				project.Blocks.Add(block);
 
 				whiteSpace = reader.ReadLineSafe();
-
 			}
 			return project;
 		}

--- a/Pandora Behaviour Engine/Properties/launchSettings.json
+++ b/Pandora Behaviour Engine/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "PandoraBehaviorEngine": {
-      "commandName": "Project",
-      "commandLineArgs": "-o:\"C:\\Users\\Monitor\\env\\Pandora Plus Testing Environment\"\r\n-skyrimDebug64"
-    }
-  }
-}


### PR DESCRIPTION
if -o is set, and that folder isn't the current folder, then clear it (minus a few specific files).

May want to double check  my logic. I believe it is right.

Also included is an additional load call to load from the .exe folder, the current/working folder and the output folder. The reason for this is so I get the templates from base Pandora, Nemsis configurations from other mods, but my ActiveMods.txt gets deployed to my custom output path.

Also, i noticed that FNIS.esp was completely deleted. I know nothing here requires it, but do other mods? or is that a huge question that would depend.

Thanks!