### PR TITLE
[Fix]: Clear mods by code data before (re)loading to prevent duplicate key errors

### DIFF
--- a/Pandora Behaviour Engine/ViewModels/EngineViewModel.cs
+++ b/Pandora Behaviour Engine/ViewModels/EngineViewModel.cs
@@ -287,6 +287,7 @@ as EngineConfigurationViewModelContainer;
             var launchDirectory = BehaviourEngine.AssemblyDirectory.FullName;
             ModViewModels.Clear(); 
             Mods.Clear();
+            modsByCode.Clear();
             var pluginsTask = SetupConfigurationOptions();
             List<IModInfo> modInfoList;
             {


### PR DESCRIPTION
`LoadAsync` clears the `ModViewModels` and `Mods` collections, but not `modsByCode` which is also filled in this method.

In practice, `LoadAsync` currently only runs once when the `EngineView` is loaded, so the duplicate key errors don't actually occur in normal usage. However, if you're already clearing `ModViewModels` and `Mods` to prevent similar issues when it's called multiple times, you should clear `modsByCode` as well. Doing so could still be useful if you for example want to benchmark the method.