### PR TITLE
[Refactor]: Simplify logic for retrieving the list of installed mods

### DIFF
--- a/Pandora Behaviour Engine/Data/NemesisModInfoProvider.cs
+++ b/Pandora Behaviour Engine/Data/NemesisModInfoProvider.cs
@@ -12,30 +12,23 @@ public class NemesisModInfoProvider : IModInfoProvider
 {
     public async Task<List<IModInfo>> GetInstalledMods(string folderPath) => await Task.Run(() => GetInstalledMods(new DirectoryInfo(folderPath)));
 
-    public List<IModInfo> GetInstalledMods(DirectoryInfo folder)
+    private static List<IModInfo> GetInstalledMods(DirectoryInfo folder)
     {
 		List<IModInfo> infoList = new List<IModInfo>();
         if (!folder.Exists) { return infoList;  }
 
-        List<FileInfo> infoFiles = new List<FileInfo>();
         var modFolders = folder.GetDirectories();
 
         foreach( var modFolder in modFolders ) 
         {
             var infoFile = new FileInfo(Path.Join(modFolder.FullName, "info.ini"));
-            if (!infoFile.Exists) 
+            if (!infoFile.Exists || infoFile.Directory is null) 
             { 
                 continue; 
             }
-            infoFiles.Add(infoFile);
+            infoList.Add(NemesisModInfo.ParseMetadata(infoFile));
         }
 
-        foreach (var file in infoFiles)
-        {
-            if (file.Directory == null) continue; 
-
-            infoList.Add(NemesisModInfo.ParseMetadata(file));
-        }
         return infoList;
 	}
 }

--- a/Pandora Behaviour Engine/Data/PandoraModInfoProvider.cs
+++ b/Pandora Behaviour Engine/Data/PandoraModInfoProvider.cs
@@ -16,26 +16,19 @@ public class PandoraModInfoProvider : IModInfoProvider
 	public async Task<List<IModInfo>> GetInstalledMods(string folderPath) => await Task.Run(() => GetInstalledMods(new DirectoryInfo(folderPath)));
 
 	private static readonly XmlSerializer xmlSerializer = new XmlSerializer(typeof(PandoraModInfo));
-	public List<IModInfo> GetInstalledMods(DirectoryInfo folder)
+	private static List<IModInfo> GetInstalledMods(DirectoryInfo folder)
 	{
 		List<IModInfo> infoList = new List<IModInfo>();
 		if (!folder.Exists) { return infoList; }
 
-		List<FileInfo> infoFiles = new List<FileInfo>();
 		var modFolders = folder.GetDirectories();
 
 		foreach (var modFolder in modFolders)
 		{
 			//var files = modFolder.GetFiles("info.xml");
 			var infoFile = new FileInfo(Path.Join(modFolder.FullName, "info.xml"));
-			if (!infoFile.Exists) { continue;  }
-			infoFiles.Add(infoFile);
-		}
-
-		foreach (var file in infoFiles)
-		{
-			if (file.Directory == null) continue;
-			using (var readStream = file.OpenRead())
+			if (!infoFile.Exists || infoFile.Directory is null) { continue; }
+			using (var readStream = infoFile.OpenRead())
 			{
 				using (var xmlReader = XmlReader.Create(readStream))
 				{
@@ -43,12 +36,10 @@ public class PandoraModInfoProvider : IModInfoProvider
 					if (modInfoObj == null) { continue; }
 
 					var modInfo = (PandoraModInfo)modInfoObj;
-					modInfo.FillData(file.Directory);
+					modInfo.FillData(infoFile.Directory);
 					infoList.Add(modInfo);
 				}
-
 			}
-			
 		}
 		return infoList;
 	}


### PR DESCRIPTION
I simplified the logic of the `IModInfoProvider.GetInstalledMods` implementations a bit by combining the `!infoFile.Exists` and `file.Directory == null` checks, so you no longer need a second `foreach`-loop on the intermediary `infoFiles` lists. I also made the methods `private` and `static`, since only the `Task`-versions are part of the public interface.