### PR TITLE
[Chore]: Update to .NET 9

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        dotnet-version: ["8.0.x"]
+        dotnet-version: ["9.0.x"]
 
     steps:
       # Ref: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net#building-and-testing-your-code
@@ -51,4 +51,4 @@ jobs:
         with:
           name: Pandora.Behaviour.Engine
           path: |
-            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net8.0
+            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net9.0

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        dotnet-version: ["8.0.x"]
+        dotnet-version: ["9.0.x"]
 
     steps:
       # Ref: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net#building-and-testing-your-code
@@ -54,7 +54,7 @@ jobs:
         with:
           name: Pandora.Behaviour.Engine
           path: |
-            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net8.0
+            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net9.0
             
       - name: Download
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish_linux_self_contained.yaml
+++ b/.github/workflows/publish_linux_self_contained.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        dotnet-version: ["8.0.x"]
+        dotnet-version: ["9.0.x"]
 
     steps:
       # Ref: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net#building-and-testing-your-code
@@ -70,28 +70,28 @@ jobs:
         with:
           name: Pandora.Behaviour.Engine.Linux-x64
           path: |
-            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net8.0/linux-x64/publish
+            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net9.0/linux-x64/publish
             
       - name: Upload Linux-Arm Build Artifact
         uses: actions/upload-artifact@v4
         with:
           name: Pandora.Behaviour.Engine.Linux-Arm
           path: |
-            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net8.0/linux-arm/publish    
+            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net9.0/linux-arm/publish    
             
       - name: Upload Linux-Arm64 Build Artifact
         uses: actions/upload-artifact@v4
         with:
           name: Pandora.Behaviour.Engine.Linux-Arm64
           path: |
-            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net8.0/linux-arm64/publish        
+            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net9.0/linux-arm64/publish        
             
       - name: Upload Linux-Musl64 Build Artifact
         uses: actions/upload-artifact@v4
         with:
           name: Pandora.Behaviour.Engine.Linux-Musl-x64
           path: |
-            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net8.0/linux-musl-x64/publish    
+            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net9.0/linux-musl-x64/publish    
             
       - name: Download Linux-x64
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish_windows_self_contained.yaml
+++ b/.github/workflows/publish_windows_self_contained.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        dotnet-version: ["8.0.x"]
+        dotnet-version: ["9.0.x"]
 
     steps:
       # Ref: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net#building-and-testing-your-code
@@ -68,21 +68,21 @@ jobs:
         with:
           name: Pandora.Behaviour.Engine.Win-x86
           path: |
-            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net8.0/win-x86/publish
+            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net9.0/win-x86/publish
             
       - name: Upload Win-x64 Build Artifact
         uses: actions/upload-artifact@v4
         with:
           name: Pandora.Behaviour.Engine.Win-x64
           path: |
-            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net8.0/win-x64/publish    
+            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net9.0/win-x64/publish    
             
       - name: Upload Win-Arm64 Build Artifact
         uses: actions/upload-artifact@v4
         with:
           name: Pandora.Behaviour.Engine.Win-Arm64
           path: |
-            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net8.0/win-arm64/publish           
+            ./Pandora Behaviour Engine/bin/${{ env.build-mode }}/net9.0/win-arm64/publish           
             
       - name: Download Linux-x64
         uses: actions/download-artifact@v4

--- a/Pandora Behaviour Engine/Models/Patch.Skyrim64/Hkx.Packfile/PackFileEdits.cs
+++ b/Pandora Behaviour Engine/Models/Patch.Skyrim64/Hkx.Packfile/PackFileEdits.cs
@@ -9,17 +9,19 @@ namespace Pandora.Models.Patch.Skyrim64.Hkx.Packfile;
 public partial class PackFileEditor
 {
 	private static readonly char[] trimChars = ['\t', '\r', '\n', ')', '('];
-	private static readonly Regex whiteSpaceRegex = new(@"(?:\s|\(|\))+", RegexOptions.Compiled);
-	private static readonly Regex escapeRegex = new(@"(?:\*|\+|\?|\||\^|\.|\#)", RegexOptions.Compiled);
+	[GeneratedRegex(@"(?:\s|\(|\))+", RegexOptions.Compiled)]
+	private static partial Regex WhiteSpaceRegex { get; }
+	[GeneratedRegex(@"(?:\*|\+|\?|\||\^|\.|\#)", RegexOptions.Compiled)]
+	private static partial Regex EscapeRegex { get; }
 	private static string NormalizeElementValue(XElement element)
 	{
-		var value = whiteSpaceRegex.Replace(element.Value.Trim(trimChars), " ");
+		var value = WhiteSpaceRegex.Replace(element.Value.Trim(trimChars), " ");
 		return value;
 	}
 
 	private static string NormalizeStringValue(string value)
 	{
-		return whiteSpaceRegex.Replace(value.Trim(trimChars), " ");
+		return WhiteSpaceRegex.Replace(value.Trim(trimChars), " ");
 	}
 	public static XElement ReplaceElement(IXMap xmap, string path, XElement element) => xmap.ReplaceElement(path, element);
 
@@ -58,7 +60,7 @@ public partial class PackFileEditor
 		//}
 		//preValue = NormalizeStringValue(preValue);
 		//oldValue = NormalizeStringValue(oldValue);
-		oldValue = whiteSpaceRegex.Replace(escapeRegex.Replace(oldValue, "\\$&"), "\\s*");
+		oldValue = WhiteSpaceRegex.Replace(EscapeRegex.Replace(oldValue, "\\$&"), "\\s*");
 
 		//ReadOnlySpan<char> headSpan = source.AsSpan(0, preValue.Length);
 		//ReadOnlySpan<char> tailSpan = source.AsSpan(preValue.Length+oldValue.Length+1);

--- a/Pandora Behaviour Engine/Models/Patch.Skyrim64/Hkx.Packfile/PackFileValidator.cs
+++ b/Pandora Behaviour Engine/Models/Patch.Skyrim64/Hkx.Packfile/PackFileValidator.cs
@@ -9,12 +9,14 @@ using XmlCake.Linq;
 
 namespace Pandora.Models.Patch.Skyrim64.Hkx.Packfile;
 
-public class PackFileValidator
+public partial class PackFileValidator
 {
 	private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
-	private static Regex EventFormat = new(@"[$]{1}eventID{1}[\[]{1}(.+)[\]]{1}[$]{1}");
-	private static Regex VarFormat = new(@"[$]{1}variableID{1}[\[]{1}(.+)[\]]{1}[$]{1}");
+	[GeneratedRegex(@"[$]{1}eventID{1}[\[]{1}(.+)[\]]{1}[$]{1}")]
+	private static partial Regex EventFormat { get; }
+	[GeneratedRegex(@"[$]{1}variableID{1}[\[]{1}(.+)[\]]{1}[$]{1}")]
+	private static partial Regex VarFormat { get; }
 
 	private Dictionary<string, int> eventIndices = [];
 	private Dictionary<string, int> variableIndices = new(StringComparer.OrdinalIgnoreCase);

--- a/Pandora Behaviour Engine/Models/Patch.Skyrim64/Hkx.Packfile/PackFileValidator.cs
+++ b/Pandora Behaviour Engine/Models/Patch.Skyrim64/Hkx.Packfile/PackFileValidator.cs
@@ -143,7 +143,7 @@ public class PackFileValidator
 		packFile.ParentProject?.AnimData?.AddDummyClipData(clipName);
 	}
 
-	public void Validate(PackFile packFile, params List<IPackFileChange>[] changeLists)
+	public void Validate(PackFile packFile, params ReadOnlySpan<List<IPackFileChange>> changeLists)
 	{
 		//if (!ValidateEventsAndVariables(packFile)) return; 
 

--- a/Pandora Behaviour Engine/Pandora Behaviour Engine.csproj
+++ b/Pandora Behaviour Engine/Pandora Behaviour Engine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -14,6 +14,7 @@
     <VersionPrefix>2.8.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
+    <CETCompat>false</CETCompat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Pandora Tests/Pandora Tests.csproj
+++ b/Pandora Tests/Pandora Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>PandoraTests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Since .NET 9 [enables CET by default](https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/9.0/cet-support) which breaks MO2's USVFS, I disabled it for the Pandora Behaviour Engine project.

I also refactored some code to use new .NET 9 features: [`params ReadOnlySpan`](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13#params-collections) and [`[GeneratedRegex]` on properties](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/libraries#generatedregex-on-properties).