### PR TITLE
[Chore]: Update GitHub release & preview actions

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 1
@@ -43,7 +43,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0 # needed for git describe
@@ -55,13 +55,13 @@ jobs:
           cache-key-suffix: Release
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v4.1.0
+        uses: gittools/actions/gitversion/setup@v4.5.0
         with:
           versionSpec: "6.3.x"
 
       - name: Determine Version
         id: version_step
-        uses: gittools/actions/gitversion/execute@v4.1.0
+        uses: gittools/actions/gitversion/execute@v4.5.0
 
       - name: Set preview version
         id: preview_version
@@ -113,7 +113,7 @@ jobs:
           Compress-Archive -Path "$outputDir/*" -DestinationPath "$zipPath"
 
       - name: Upload to NexusMods
-        uses: Nexus-Mods/upload-action@v1.0.0-beta.3
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.5
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
           file_group_id: ${{ secrets.NEXUSMODS_GROUP_ID_BLD }}
@@ -121,3 +121,6 @@ jobs:
           display_name: Pandora Behaviour Engine Preview
           version: ${{ steps.preview_version.outputs.version }}
           description: "Latest generated preview release. Use if you want/need unreleased features. May contain bugs."
+          primary_mod_manager_download: false
+          allow_mod_manager_download: true
+          show_requirements_pop_up: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       informationalVersion: ${{ steps.version_step.outputs.informationalVersion }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0 # 0 need for GitVersion
@@ -35,13 +35,13 @@ jobs:
           cache-key-suffix: ${{ env.PROFILE }}
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v4.1.0
+        uses: gittools/actions/gitversion/setup@v4.5.0
         with:
           versionSpec: "6.3.x"
 
       - name: Determine Version
         id: version_step
-        uses: gittools/actions/gitversion/execute@v4.1.0
+        uses: gittools/actions/gitversion/execute@v4.5.0
 
       - name: Set output paths
         id: set_paths
@@ -107,7 +107,7 @@ jobs:
           #   output-dir: Output.Linux-Musl-x64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 1
@@ -145,10 +145,13 @@ jobs:
 
       - name: Upload to NexusMods
         if: matrix.rid == 'win-x64'
-        uses: Nexus-Mods/upload-action@v1.0.0-beta.3
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.5
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
           file_group_id: ${{ secrets.NEXUSMODS_GROUP_ID }}
           filename: "${{ matrix.output-dir }}/Pandora_Behaviour_Engine_${{ github.ref_name }}_${{ matrix.rid }}_net.zip"
           display_name: Pandora Behaviour Engine ${{ github.ref_name }}
           version: ${{ needs.build.outputs.fullSemVer }}
+          primary_mod_manager_download: true
+          allow_mod_manager_download: true
+          show_requirements_pop_up: true


### PR DESCRIPTION
The last 2 runs of the [publish-bleeding-edge](https://github.com/Monitor221hz/Pandora-Behaviour-Engine-Plus/actions/runs/25957740016/job/76307600912#logs) workflow failed during the "Upload to Nexus Mods" step. I hope updating the `Nexus-Mods/upload-action` will fix it. I also updated `actions/checkout` and `gittools/actions/gitversion` in the bleeding-edge and release workflows.

Even though this PR doesn't include functional changes, I set `preview` as target branch instead of `main` to trigger the bleeding-edge workflow again since it failed last time.